### PR TITLE
Corretta pre-condizione uc01

### DIFF
--- a/src-doc/contenuti/use-cases/uc01.tex
+++ b/src-doc/contenuti/use-cases/uc01.tex
@@ -7,7 +7,7 @@ Come utente non loggato, voglio autenticarmi utilizzando le mie username e passw
 Utente non loggato.
 
 \paragraph{Precondizioni:}
-Il sistema non riconosce l'utente.
+L'utente fa parte del gruppo di utenti che possono effettuare l'accesso al sistema, e non è riconosciuto da esso.
 
 \paragraph{Post-condizioni:}
 Il sistema riconosce l'utente, che potrà essere:


### PR DESCRIPTION
Ho corretto la pre-condizione di uc01, specificando che l'utente che vuole fare il login, deve essere all'interno degli utenti che possono farlo.
Va bene @alessandro-massarenti ?